### PR TITLE
Added -salt & -password definitions in auth_by_scrypt method

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -70,6 +70,10 @@ def auth_by_seed():
 
 
 def auth_by_scrypt(c):
+     if c.contains_definitions('salt') and c.contains_definitions('password'):
+        salt = c.get_definition('salt')
+        password = c.get_definition('password')
+    else:
     salt = getpass.getpass("Please enter your Scrypt Salt (Secret identifier): ")
     password = getpass.getpass("Please enter your Scrypt password (masked): ")
 


### PR DESCRIPTION
Try to avoid interactive "generate_auth_file" command execution by sending Salt & Password parameters in CLI
example:
./silkaj generate_auth_file --auth-scrypt --salt=mySALT --password=myPASSWORD